### PR TITLE
use int instead time.Duration in config

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -73,7 +73,7 @@ func main() { //nolint:funlen
 		log.RegisterExitHandler(func() {
 			cancel()
 			// wait before shutdown
-			time.Sleep(*config.Get().GracePeriod)
+			time.Sleep(config.Get().GetGracePeriod())
 		})
 
 		select {
@@ -94,5 +94,5 @@ func main() { //nolint:funlen
 
 	log.Error("Server has stoped...")
 
-	time.Sleep(*config.Get().GracePeriod)
+	time.Sleep(config.Get().GetGracePeriod())
 }

--- a/internal/internal.go
+++ b/internal/internal.go
@@ -82,7 +82,7 @@ func startServerTLS(ctx context.Context, sCert tls.Certificate) {
 	go func() {
 		<-ctx.Done()
 
-		ctx, cancel := context.WithTimeout(context.Background(), *config.Get().GracePeriod)
+		ctx, cancel := context.WithTimeout(context.Background(), config.Get().GetGracePeriod())
 		defer cancel()
 
 		_ = server.Shutdown(ctx) //nolint:contextcheck
@@ -111,7 +111,7 @@ func startMetricsServer(ctx context.Context) {
 	go func() {
 		<-ctx.Done()
 
-		ctx, cancel := context.WithTimeout(context.Background(), *config.Get().GracePeriod)
+		ctx, cancel := context.WithTimeout(context.Background(), config.Get().GetGracePeriod())
 		defer cancel()
 
 		_ = server.Shutdown(ctx) //nolint:contextcheck

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -25,7 +25,7 @@ import (
 )
 
 const (
-	defaultGracePeriod             = 5 * time.Second
+	defaultGracePeriod             = 5
 	defaultAddr                    = ":8443"
 	defaultMetricsAddr             = ":31080"
 	defaultContainerResourceCPU    = "100m"
@@ -33,7 +33,7 @@ const (
 )
 
 type Params struct {
-	GracePeriod          *time.Duration
+	GracePeriodSeconds   *int
 	ConfigFile           *string
 	KubeConfigFile       *string
 	LogLevel             *string
@@ -51,7 +51,7 @@ type Params struct {
 }
 
 var param = Params{
-	GracePeriod:          flag.Duration("graceperiod", defaultGracePeriod, "grace period"),
+	GracePeriodSeconds:   flag.Int("graceperiod", defaultGracePeriod, "grace period"),
 	ConfigFile:           flag.String("config", "", "config file"),
 	KubeConfigFile:       flag.String("kubeconfig", "", "kubeconfig file"),
 	LogLevel:             flag.String("log.level", "INFO", "log level"),
@@ -65,6 +65,10 @@ var param = Params{
 	SentryEndpoint:       flag.String("sentry.endpoint", "", "sentry endpoint"),
 	SentryToken:          flag.String("sentry.token", "", "sentry token"),
 	SentryDSN:            flag.String("sentry.dsn", os.Getenv("SENTRY_DSN"), "sentry DSN for error reporting"),
+}
+
+func (p *Params) GetGracePeriod() time.Duration {
+	return time.Duration(*p.GracePeriodSeconds) * time.Second
 }
 
 func Get() *Params {

--- a/pkg/sentry/sentry.go
+++ b/pkg/sentry/sentry.go
@@ -69,6 +69,10 @@ func CreateCache(ctx context.Context) error {
 	}
 
 	for _, project := range projects {
+		if ctx.Err() != nil {
+			return errors.Wrap(ctx.Err(), "context canceled")
+		}
+
 		keys, err := GetProjectKeys(ctx, project)
 		if err != nil {
 			return errors.Wrap(err, "failed to get keys")


### PR DESCRIPTION
use primitives types in config - use seconds instead of time.Duration