### PR TITLE
fix empty map value

### DIFF
--- a/pkg/conditions/conditions_test.go
+++ b/pkg/conditions/conditions_test.go
@@ -337,7 +337,16 @@ func TestCheckConditions(t *testing.T) { //nolint:funlen,maintidx
 			Match: true,
 			Conditions: []types.Conditions{
 				{
-					Key:      ".Namespace",
+					Key:      ".NamespaceAnnotations.SOMEFAKE",
+					Operator: "Empty",
+				},
+			},
+		},
+		{
+			Match: false,
+			Conditions: []types.Conditions{
+				{
+					Key:      ".NamespaceAnnotations.SOMEFAKE",
 					Operator: "NotEmpty",
 				},
 			},

--- a/pkg/patch/env/env_test.go
+++ b/pkg/patch/env/env_test.go
@@ -140,7 +140,7 @@ func TestFormatEnv(t *testing.T) {
 		"TEST1:1/2/3",
 		"TEST2:test",
 		"TEST3:testapp",
-		"TEST4:<no value>",
+		"TEST4:",
 	}
 
 	for i, returnResult := range returnResults {

--- a/pkg/template/template.go
+++ b/pkg/template/template.go
@@ -25,7 +25,7 @@ import (
 )
 
 func Get(containerInfo *types.ContainerInfo, value string) (string, error) {
-	tmpl, err := template.New("tmpl").Funcs(template.FuncMap{
+	tmpl, err := template.New("tmpl").Option("missingkey=zero").Funcs(template.FuncMap{
 		// regexp string by pattern
 		"regexp": func(pattern string, value string) []string {
 			return regexp.MustCompile(pattern).FindStringSubmatch(value)


### PR DESCRIPTION
fix go template on empy map value, if go map has no key on templating it return `<no value>` it's confusing on conditions, for example:
```
conditions:
- key: .NamespaceAnnotations.region
  operator: NotEmpty
```
not working because if no value `.NamespaceAnnotations.region` it return `<no value>` and this value is not empty