### PR TITLE
refactor sentry settings

### DIFF
--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -133,8 +133,6 @@ func TestMutation(t *testing.T) { //nolint:funlen
 		}
 
 		for _, test := range tests {
-			test := test
-
 			t.Run(test.name, func(t *testing.T) {
 				t.Parallel()
 

--- a/internal/internal.go
+++ b/internal/internal.go
@@ -64,7 +64,7 @@ func Start(ctx context.Context) error {
 
 		log.Info("Creating patch.json...")
 
-		if err := os.WriteFile("patch.json", patchBytes, 0o600); err != nil { //nolint:gomnd
+		if err := os.WriteFile("patch.json", patchBytes, 0o600); err != nil { //nolint:gomnd,mnd
 			log.WithError(err).Error()
 		}
 

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -498,6 +498,7 @@ func GetImageInfo(image string) (*types.ContainerImage, error) {
 
 	result := types.ContainerImage{
 		Domain: reference.Domain(refName),
+		Path:   reference.Path(refName),
 		Name:   image,
 		Slug:   strings.Trim(imageName, "-"),
 		Tag:    "latest",
@@ -522,8 +523,18 @@ func TestPOD(ctx context.Context, namespace, podName string) ([]byte, error) {
 	}
 
 	input := &MutateInput{
+		Namespace: &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: namespace,
+			},
+		},
 		AdmissionReview: &admissionv1.AdmissionReview{
 			Request: &admissionv1.AdmissionRequest{
+				Resource: metav1.GroupVersionResource{
+					Group:    "",
+					Version:  "v1",
+					Resource: "pods",
+				},
 				Object: runtime.RawExtension{
 					Raw: podJSON,
 				},

--- a/pkg/api/api_test.go
+++ b/pkg/api/api_test.go
@@ -130,36 +130,42 @@ func TestGetImageInfo(t *testing.T) {
 
 	tests["10.10.10.10:5000/product/main/backend:release-20220516-1"] = &types.ContainerImage{
 		Domain: "10.10.10.10:5000",
+		Path:   "product/main/backend",
 		Name:   "10.10.10.10:5000/product/main/backend:release-20220516-1",
 		Slug:   "product-main-backend",
 		Tag:    "release-20220516-1",
 	}
 	tests["10.10.10.10:5000/product/main/front:release-20220516-1"] = &types.ContainerImage{
 		Domain: "10.10.10.10:5000",
+		Path:   "product/main/front",
 		Name:   "10.10.10.10:5000/product/main/front:release-20220516-1",
 		Slug:   "product-main-front",
 		Tag:    "release-20220516-1",
 	}
 	tests["domain.com/hipages/php-fpm_exporter:1"] = &types.ContainerImage{
 		Domain: "domain.com",
+		Path:   "hipages/php-fpm_exporter",
 		Name:   "domain.com/hipages/php-fpm_exporter:1",
 		Slug:   "hipages-php-fpm-exporter",
 		Tag:    "1",
 	}
 	tests["domain.com/paskalmaksim/envoy-docker-image:v0.3.8"] = &types.ContainerImage{
 		Domain: "domain.com",
+		Path:   "paskalmaksim/envoy-docker-image",
 		Name:   "domain.com/paskalmaksim/envoy-docker-image:v0.3.8",
 		Slug:   "paskalmaksim-envoy-docker-image",
 		Tag:    "v0.3.8",
 	}
 	tests["paskalmaksim/envoy-docker-image:v0.3.8"] = &types.ContainerImage{
 		Domain: "docker.io",
+		Path:   "paskalmaksim/envoy-docker-image",
 		Name:   "paskalmaksim/envoy-docker-image:v0.3.8",
 		Slug:   "paskalmaksim-envoy-docker-image",
 		Tag:    "v0.3.8",
 	}
 	tests["paskalmaksim/envoy-docker-image"] = &types.ContainerImage{
 		Domain: "docker.io",
+		Path:   "paskalmaksim/envoy-docker-image",
 		Name:   "paskalmaksim/envoy-docker-image",
 		Slug:   "paskalmaksim-envoy-docker-image",
 		Tag:    "latest",
@@ -172,7 +178,7 @@ func TestGetImageInfo(t *testing.T) {
 		}
 
 		if !reflect.DeepEqual(requre, formattedImage) {
-			t.Fatalf("must be %s, got %s", requre, formattedImage)
+			t.Fatalf("must be:\n%+v, got:\n%+v", requre, formattedImage)
 		}
 	}
 }

--- a/pkg/conditions/conditions_test.go
+++ b/pkg/conditions/conditions_test.go
@@ -440,8 +440,6 @@ func TestCheckConditions(t *testing.T) { //nolint:funlen,maintidx
 	}
 
 	for testID, test := range tests {
-		test := test
-
 		t.Run(strconv.Itoa(testID), func(t *testing.T) {
 			t.Parallel()
 

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -14,6 +14,7 @@ package config_test
 
 import (
 	"flag"
+	"reflect"
 	"testing"
 	"time"
 
@@ -33,11 +34,11 @@ func TestConfig(t *testing.T) {
 
 	t.Log("config:", config.Get().String())
 
-	if *config.Get().SentryEndpoint != "1" {
+	if *config.Get().CertFile != "1" {
 		t.Fatal("not valid SentryEndpoint")
 	}
 
-	if *config.Get().SentryToken != "2" {
+	if *config.Get().KeyFile != "2" {
 		t.Fatal("not valid SentryToken")
 	}
 
@@ -68,5 +69,32 @@ func TestVersion(t *testing.T) {
 
 	if config.GetVersion() != "dev" {
 		t.Fatal("version is not dev")
+	}
+}
+
+func TestSentryPrefix(t *testing.T) {
+	param := &config.Params{
+		Sentry: &config.Sentry{
+			Prefixes: []*config.SentryPrefix{
+				{
+					Pattern: "^test$",
+					Name:    "testname",
+				},
+			},
+		},
+	}
+
+	if prefix := param.Sentry.GetPrefixes("aa"); len(prefix) != 0 {
+		t.Fatal("not valid prefix aa")
+	}
+
+	if prefix := param.Sentry.GetPrefixes("test"); len(prefix) != 1 || prefix[0] != "testname" {
+		t.Fatal("not valid prefix test")
+	}
+
+	t.Setenv("SENTRY_PROJECTS_PREFIX", "test2,test3")
+
+	if prefix := param.Sentry.GetPrefixes("test"); !reflect.DeepEqual(prefix, []string{"testname", "test2", "test3"}) {
+		t.Fatal("not valid prefix test2, not valid: ", prefix)
 	}
 }

--- a/pkg/config/testdata/test-config.yaml
+++ b/pkg/config/testdata/test-config.yaml
@@ -1,2 +1,2 @@
-sentryendpoint: "1"
-sentrytoken: "2"
+certfile: "1"
+keyfile: "2"

--- a/pkg/patch/custompatch/custompatch_test.go
+++ b/pkg/patch/custompatch/custompatch_test.go
@@ -193,8 +193,6 @@ func TestCustompatch(t *testing.T) { //nolint:funlen
 	}
 
 	for _, test := range tests {
-		test := test
-
 		t.Run(fmt.Sprintf("%+v", test), func(t *testing.T) {
 			t.Parallel()
 

--- a/pkg/patch/env/env.go
+++ b/pkg/patch/env/env.go
@@ -80,9 +80,7 @@ func (p *Patch) FormatEnv(containerInfo *types.ContainerInfo, containersEnv []co
 
 	formattedEnv := make([]corev1.EnvVar, 0)
 
-	for _, containerEnv := range containersEnv {
-		item := containerEnv
-
+	for _, item := range containersEnv {
 		item.Value, err = template.Get(containerInfo, item.Value)
 		if err != nil {
 			return nil, errors.Wrap(err, "error template value")

--- a/pkg/patch/patch_test.go
+++ b/pkg/patch/patch_test.go
@@ -104,8 +104,6 @@ func TestIgnorePatch(t *testing.T) { //nolint:funlen
 	}
 
 	for _, test := range tests {
-		test := test
-
 		t.Run(fmt.Sprintf("%+v", test), func(t *testing.T) {
 			t.Parallel()
 

--- a/pkg/patch/resources/resources_test.go
+++ b/pkg/patch/resources/resources_test.go
@@ -158,8 +158,6 @@ func TestGetDefaultResources(t *testing.T) { //nolint:funlen
 	}
 
 	for _, test := range tests {
-		test := test
-
 		t.Run(fmt.Sprintf("%+v", test), func(t *testing.T) {
 			t.Parallel()
 

--- a/pkg/sentry/sentry_test.go
+++ b/pkg/sentry/sentry_test.go
@@ -13,14 +13,17 @@ limitations under the License.
 package sentry_test
 
 import (
+	"bytes"
 	"context"
-	"flag"
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"strings"
 	"testing"
 
+	"github.com/maksim-paskal/pod-admission-controller/pkg/config"
 	"github.com/maksim-paskal/pod-admission-controller/pkg/sentry"
+	log "github.com/sirupsen/logrus"
 )
 
 var ts = httptest.NewServer(GetHandler())
@@ -30,6 +33,9 @@ func GetHandler() http.Handler {
 
 	mux.HandleFunc("/api/0/projects/", projects)
 	mux.HandleFunc("/api/0/projects/test-org/test-project/keys/", projectkey)
+	mux.HandleFunc("/api/0/projects/the-interstellar-jurisdiction/the-spoiled-yoghurt/keys/", projectkey)
+	mux.HandleFunc("/api/0/projects/the-interstellar-jurisdiction/prime-mover/keys/", projectkey)
+	mux.HandleFunc("/api/0/projects/the-interstellar-jurisdiction/pump-station/keys/", projectkey)
 
 	return mux
 }
@@ -45,7 +51,7 @@ func projects(w http.ResponseWriter, _ *http.Request) {
 	_, _ = w.Write(projectsByte)
 }
 
-func projectkey(w http.ResponseWriter, _ *http.Request) {
+func projectkey(w http.ResponseWriter, r *http.Request) {
 	projectsByte, err := os.ReadFile("testdata/projectkey.json")
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
@@ -53,40 +59,152 @@ func projectkey(w http.ResponseWriter, _ *http.Request) {
 		return
 	}
 
+	projectsByte = bytes.ReplaceAll(projectsByte,
+		[]byte("https://cec9dfceb0b74c1c9a5e3c135585f364@sentry.io/2"),
+		[]byte("https://"+strings.Split(r.URL.Path, "/")[5]+"@sentry.io/2"),
+	)
+
 	_, _ = w.Write(projectsByte)
 }
 
-func TestAPI(t *testing.T) {
+func Test(t *testing.T) { //nolint:funlen,cyclop
 	t.Parallel()
-
-	if err := flag.Set("sentry.endpoint", ts.URL); err != nil {
-		t.Fatal(err)
-	}
 
 	ctx := context.Background()
 
-	projects, err := sentry.GetProjects(ctx)
-	if err != nil {
-		t.Fatal(err)
-	}
+	log.SetLevel(log.DebugLevel)
 
-	if len(projects) != 3 {
-		t.Fatalf("expected 3 projects, got %d", len(projects))
-	}
-
-	project := sentry.Project{
-		Organization: sentry.Organization{
-			Slug: "test-org",
+	params := config.Params{
+		Sentry: &config.Sentry{
+			Endpoint:     ts.URL,
+			Relay:        "http://localhost:3000",
+			Token:        "test-token",
+			Organization: "test-org",
+			Prefixes: []*config.SentryPrefix{
+				{
+					Pattern: "^prime-.+$",
+					Name:    "prime-",
+				},
+			},
+			Projects: map[string]string{
+				"the-spoiled-yoghurt": "some/test/image",
+				"mover":               "prime/mover/image",
+				"pump-station":        "pump/station/image",
+			},
 		},
-		Slug: "test-project",
 	}
 
-	projectkey, err := sentry.GetProjectKeys(ctx, project)
-	if err != nil {
+	config.Set(params)
+
+	if err := sentry.CreateCache(ctx); err != nil {
 		t.Fatal(err)
 	}
 
-	if len(projectkey) != 1 {
-		t.Fatalf("expected 1 project key, got %d", len(projectkey))
-	}
+	t.Run("TestGetProjects", func(t *testing.T) {
+		t.Parallel()
+
+		projects, err := sentry.GetProjects(ctx)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if expected := 3; len(projects) != expected {
+			t.Fatalf("expected %d projects, got %d", expected, len(projects))
+		}
+	})
+
+	t.Run("TestGetProjectKeys", func(t *testing.T) {
+		t.Parallel()
+
+		project := sentry.Project{
+			Organization: sentry.Organization{
+				Slug: "test-org",
+			},
+			Slug: "test-project",
+		}
+
+		projectkey, err := sentry.GetProjectKeys(ctx, project)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if expected := 1; len(projectkey) != expected {
+			t.Fatalf("expected %d project key, got %d", expected, len(projectkey))
+		}
+
+		if expected := "http://test-project@localhost:3000/2"; projectkey[0].Dsn.Public != expected {
+			t.Fatalf("expected %s project key, got %s", expected, projectkey[0].Dsn.Public)
+		}
+	})
+
+	t.Run("GetSentryDSN", func(t *testing.T) {
+		t.Parallel()
+
+		type test struct {
+			imagePath string
+			dsn       string
+			namespace string
+		}
+
+		tests := []test{
+			{
+				imagePath: "docker.io/some/test/image:latest",
+				dsn:       "",
+			},
+			{
+				imagePath: "some/test/image",
+				dsn:       "http://the-spoiled-yoghurt@localhost:3000/2",
+			},
+			{
+				imagePath: "some/test/image/test",
+				dsn:       "http://the-spoiled-yoghurt@localhost:3000/2",
+			},
+			{
+				imagePath: "pump/station/image",
+				dsn:       "http://pump-station@localhost:3000/2",
+			},
+			{
+				imagePath: "prime/mover/image",
+				dsn:       "http://prime-mover@localhost:3000/2",
+				namespace: "prime-test",
+			},
+			{
+				imagePath: "/some/test/fimage",
+				dsn:       "",
+			},
+			{
+				imagePath: "/fake",
+				dsn:       "",
+			},
+		}
+
+		for _, test := range tests {
+			t.Run(test.imagePath, func(t *testing.T) {
+				dsn, ok := sentry.GetSentryDSN(test.namespace, test.imagePath)
+				t.Log(dsn, ok)
+				// if dsn is empty, ok should be true
+				if ok != (len(test.dsn) != 0) {
+					t.Fatalf("expected %t, got %t", len(test.dsn) != 0, ok)
+				}
+
+				if len(test.dsn) != 0 && dsn != test.dsn {
+					t.Fatalf("expected %s dsn, got %s", test.dsn, dsn)
+				}
+			})
+		}
+	})
+
+	t.Run("TestGetRelayDSN", func(t *testing.T) {
+		t.Parallel()
+
+		key := sentry.Key{
+			Dsn: sentry.KeyDsn{
+				Public: "https://qwerty@sentry.io/2",
+			},
+		}
+
+		if expected := "http://qwerty@localhost:3000/2"; key.GetRelayDSN() != expected {
+			t.Fatalf("expected %s dsn, got %s", expected, key.GetRelayDSN())
+		}
+	})
 }

--- a/pkg/template/template_test.go
+++ b/pkg/template/template_test.go
@@ -30,7 +30,7 @@ func TestTemplateValue(t *testing.T) {
 	cases := make(map[string]string)
 
 	cases[`{{ index (regexp "/(.+):(.+)$" .Image.Name) 2 }}`] = "e"
-	cases[`{{ GetSentryDSN (index (regexp "/(.+):(.+)$" .Image.Name) 1) }}`] = ""
+	cases[`{{ GetSentryDSN "" (index (regexp "/(.+):(.+)$" .Image.Name) 1) }}`] = ""
 	cases[`{{ index (regexp "/(.+):(.+)$" "/1/2/3/4:main") 2 }}`] = "main"
 	cases[`{{ indexUnknown (regexp "/(.+):(.+)$" "/1/2/3/4:main") 3 }}`] = "unknown"
 	cases[`{{ indexUnknown (regexp "/(.+):(.+)$" .Image.Name) 2 }}`] = "e"

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -176,6 +176,7 @@ func (c *Condition) Validate() error {
 
 type ContainerImage struct {
 	Domain string
+	Path   string
 	Name   string
 	Slug   string
 	Tag    string


### PR DESCRIPTION
reorganize settings for sentry:
```yaml
sentry:
  # sentry endpoint
  endpoint: https://sentry.domain.com
  # (optional) use relay address instead sentry endpoint
  relay: http://sentry-relay.sentry-relay.svc.cluster.local
  # token for sentry API
  token: <token>
  # name of sentry org
  organization: org
  # (optional) use additional setry project prefixes 
  prefixes:
  - pattern: ^regexp$
    name: some-prefix-
  # mapping sentry project with docker image path
  projects:
    some-service: path/to/docker/image
  # (optional) to make it more reliable - use sentry projects from config instead doing request to sentry API
  cache:
    sentry-project: http://123@sentry-relay.sentry-relay.svc.cluster.local/123
```