### PR TITLE
Add topology spreads

### DIFF
--- a/pkg/patch/patch.go
+++ b/pkg/patch/patch.go
@@ -24,6 +24,7 @@ import (
 	"github.com/maksim-paskal/pod-admission-controller/pkg/patch/pullsecrets"
 	"github.com/maksim-paskal/pod-admission-controller/pkg/patch/resources"
 	"github.com/maksim-paskal/pod-admission-controller/pkg/patch/tolerations"
+	"github.com/maksim-paskal/pod-admission-controller/pkg/patch/topologyspread"
 	"github.com/maksim-paskal/pod-admission-controller/pkg/types"
 	"github.com/pkg/errors"
 )
@@ -41,6 +42,7 @@ var allPatchs = []Patch{
 	&tolerations.Patch{},
 	&pullsecrets.Patch{},
 	&custompatch.Patch{},
+	&topologyspread.Patch{},
 }
 
 func NewPatch(ctx context.Context, containerInfo *types.ContainerInfo) ([]types.PatchOperation, error) {

--- a/pkg/patch/topologyspread/topologyspread.go
+++ b/pkg/patch/topologyspread/topologyspread.go
@@ -1,0 +1,69 @@
+/*
+Copyright paskal.maksim@gmail.com
+Licensed under the Apache License, Version 2.0 (the "License")
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package topologyspread
+
+import (
+	"context"
+	"slices"
+
+	"github.com/maksim-paskal/pod-admission-controller/pkg/types"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var podLabelsIgnore = []string{
+	"pod-template-hash",
+	"controller-revision-hash",
+	"statefulset.kubernetes.io/pod-name",
+	"apps.kubernetes.io/pod-index",
+}
+
+type Patch struct{}
+
+func (p *Patch) Create(_ context.Context, containerInfo *types.ContainerInfo) ([]types.PatchOperation, error) {
+	patch := make([]types.PatchOperation, 0)
+
+	podLabels := map[string]string{}
+
+	for key, value := range containerInfo.PodLabels {
+		if slices.Contains(podLabelsIgnore, key) {
+			continue
+		}
+
+		podLabels[key] = value
+	}
+
+	for _, selectedRule := range containerInfo.SelectedRules {
+		if !selectedRule.AddTopologySpread.Enabled {
+			continue
+		}
+
+		topologySpreadConstraints := selectedRule.AddTopologySpread.Clone().TopologySpreadConstraints
+
+		for i := range topologySpreadConstraints {
+			topologySpreadConstraints[i].LabelSelector = &metav1.LabelSelector{
+				MatchLabels: podLabels,
+			}
+		}
+
+		patch = append(patch, types.PatchOperation{
+			Op:    "add",
+			Path:  "/spec/topologySpreadConstraints",
+			Value: topologySpreadConstraints,
+		})
+
+		// only one rule can be applied
+		break
+	}
+
+	return patch, nil
+}

--- a/pkg/patch/topologyspread/topologyspread_test.go
+++ b/pkg/patch/topologyspread/topologyspread_test.go
@@ -1,0 +1,66 @@
+/*
+Copyright paskal.maksim@gmail.com
+Licensed under the Apache License, Version 2.0 (the "License")
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package topologyspread_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/maksim-paskal/pod-admission-controller/pkg/patch/topologyspread"
+	"github.com/maksim-paskal/pod-admission-controller/pkg/types"
+	corev1 "k8s.io/api/core/v1"
+)
+
+func TestLifeCyclePatch(t *testing.T) {
+	t.Parallel()
+
+	patch := topologyspread.Patch{}
+
+	containerInfo := &types.ContainerInfo{
+		PodLabels: map[string]string{
+			"app":               "test",
+			"env":               "dev",
+			"pod-template-hash": "123",
+		},
+		PodContainer: &types.PodContainer{
+			Type:      "container",
+			Container: &corev1.Container{},
+			Pod:       &corev1.Pod{},
+		},
+		SelectedRules: []*types.Rule{
+			{
+				AddTopologySpread: types.AddTopologySpread{
+					Enabled: true,
+					TopologySpreadConstraints: []corev1.TopologySpreadConstraint{
+						{
+							MaxSkew: 1,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	patchOps, err := patch.Create(context.TODO(), containerInfo)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(patchOps) != 1 {
+		t.Fatal("1 patch must be created")
+	}
+
+	if patchOps[0].Op != "add" || patchOps[0].Path != "/spec/topologySpreadConstraints" {
+		t.Fatalf("not corrected patch %s", patchOps[0].String())
+	}
+}

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -75,6 +75,26 @@ type AddDefaultResources struct {
 	RemoveResources bool
 }
 
+type AddTopologySpread struct {
+	Enabled                   bool
+	TopologySpreadConstraints []corev1.TopologySpreadConstraint
+}
+
+func (a *AddTopologySpread) Clone() AddTopologySpread {
+	my, err := json.Marshal(a)
+	if err != nil {
+		log.Warn(err)
+
+		return AddTopologySpread{}
+	}
+
+	var clone AddTopologySpread
+
+	_ = json.Unmarshal(my, &clone)
+
+	return clone
+}
+
 type Rule struct {
 	Debug                     bool
 	Name                      string
@@ -86,6 +106,7 @@ type Rule struct {
 	Tolerations               []corev1.Toleration
 	ImagePullSecrets          []corev1.LocalObjectReference
 	CustomPatches             []PatchOperation
+	AddTopologySpread         AddTopologySpread
 }
 
 func (r *Rule) Logf(format string, args ...interface{}) {


### PR DESCRIPTION
Add topologySpreadConstraints to pods 
```yaml
- addtopologySpread:
    enabled: true
    topologySpreadConstraints:
    - maxSkew: 1
      topologyKey: capacity-spread
      whenUnsatisfiable: ScheduleAnyway
      matchLabelKeys:
      - pod-template-hash
    - maxSkew: 1
      topologyKey: kubernetes.io/hostname
      whenUnsatisfiable: DoNotSchedule
      matchLabelKeys:
      - pod-template-hash
  conditions:
  - key: .OwnerKind
    operator: In
    values:
    - ReplicaSet
    - StatefulSet
 ```