### PR TITLE
feat: Add GetAnnotation template func

### DIFF
--- a/pkg/template/template_test.go
+++ b/pkg/template/template_test.go
@@ -24,6 +24,12 @@ func TestTemplateValue(t *testing.T) {
 	t.Setenv("SOME_TEST_ENV", "test")
 
 	containerInfo := &types.ContainerInfo{
+		NamespaceAnnotations: map[string]string{
+			"test1": "value1",
+		},
+		PodAnnotations: map[string]string{
+			"test": "value",
+		},
 		Image: &types.ContainerImage{Name: "/a/b/c/d:e"},
 	}
 
@@ -37,6 +43,8 @@ func TestTemplateValue(t *testing.T) {
 	cases[`{{ ResolveFallback "fakedomain.fakedomain" "fakefallback" }}`] = "fakefallback"
 	cases[`{{ env "SOME_TEST_ENV" }}`] = "test"
 	cases[`{{ env "SOME_TEST_ENV" | replace "te" "de" }}`] = "dest"
+	cases[`{{ .GetAnnotation "test" }}`] = "value"
+	cases[`{{ .GetAnnotation "test1" }}`] = "value1"
 
 	for k, v := range cases {
 		value, err := template.Get(containerInfo, k)

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -230,6 +230,14 @@ func (c *ContainerInfo) String() string {
 	return string(out)
 }
 
+func (c *ContainerInfo) GetAnnotation(key string) string {
+	if val, ok := c.GetPodAnnotation(key); ok {
+		return val
+	}
+
+	return ""
+}
+
 // return namespaced pod annotation value.
 func (c *ContainerInfo) GetPodAnnotation(key string) (string, bool) {
 	if val, ok := c.PodAnnotations[key]; ok {


### PR DESCRIPTION
This pull request adds functionality to retrieve pod annotation values from the `ContainerInfo` struct and includes new tests to verify this behavior. The main focus is on improving how annotations are accessed and tested within the codebase.

### Annotation access improvements

* Added a new method `GetAnnotation` to the `ContainerInfo` struct in `pkg/types/types.go`, allowing retrieval of pod annotation values by key.

### Testing enhancements

* Updated the test data in `pkg/template/template_test.go` to include `NamespaceAnnotations` and `PodAnnotations` for `ContainerInfo`.
* Added test cases in `TestTemplateValue` to verify that the new `.GetAnnotation` template function returns the correct annotation values.