### PR TITLE
feat: Add test for NodeSelector field condition matching

### DIFF
--- a/pkg/conditions/conditions_test.go
+++ b/pkg/conditions/conditions_test.go
@@ -66,6 +66,9 @@ func TestCheckConditions(t *testing.T) { //nolint:funlen,maintidx
 					},
 				},
 				Spec: corev1.PodSpec{
+					NodeSelector: map[string]string{
+						"testKey": "testValue",
+					},
 					Volumes: []corev1.Volume{
 						{
 							Name: "test-volume-01",
@@ -434,6 +437,16 @@ func TestCheckConditions(t *testing.T) { //nolint:funlen,maintidx
 					Key:      ".PodContainer.OwnerKind",
 					Operator: "equal",
 					Value:    "ReplicaSet",
+				},
+			},
+		},
+		{
+			Match: true,
+			Conditions: []types.Condition{
+				{
+					Key:      ".PodContainer.Pod.Spec.NodeSelector",
+					Operator: "regexp",
+					Value:    `(testKey):.+`,
 				},
 			},
 		},


### PR DESCRIPTION
## Summary
- Added `NodeSelector` field to the test pod spec in `TestCheckConditions`
- Added a new test case verifying regexp condition matching against `.PodContainer.Pod.Spec.NodeSelector`

## Test plan
- [x] Existing tests pass
- [x] New test case covers regexp matching on `NodeSelector` key-value pairs